### PR TITLE
Hook reuse

### DIFF
--- a/.github/workflows/.deploy-test.yml
+++ b/.github/workflows/.deploy-test.yml
@@ -1,0 +1,21 @@
+name: Deploy to npm
+
+on:
+  push:
+    branches: [ dev ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install    
+      - run: npm run build
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          tag: test
+          token: ${{ secrets.NPM_TOKEN }}
+          

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, dev ]
 
 jobs:
   test_pr:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy to npm
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 10
+      - run: npm install    
+      - run: npm run build
       - uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.*
+.github/
+src/
+test/
+jest.config.js
+tsconfig.json

--- a/README.md
+++ b/README.md
@@ -11,7 +11,22 @@ npm install react-hook-popup
 ## Usage
 
 ### Basic Usage
-React Hook Popup is completely centered around one single, simple to use hook: `usePopup`.
+React Hook Popup is completely centered around one single, simple to use hook: `usePopup`. It can be imported like
+
+```javascript
+import { usePopup } from 'react-hook-popup';
+```
+
+Any component that uses this hook __must appear below the `<PopupProvider>` component__ in the tree. You probably want to wrap your whole application in this component.
+
+```javascript
+import { PopupProvider } from 'react-hook-popup';
+```
+```javascript
+<PopupProvider>
+    <YourApplication />
+</PopupProvider>
+```
 
 The `usePopup` hook takes two arguments: 
 - A `string` key that is unique to each popup.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-hook-popup",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Easily manage popups like alerts and modals in React with a single hook",
   "homepage": "https://github.com/aidanjw1/react-hook-popup#readme",
   "repository": "github:aidanjw1/react-hook-popup",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-hook-popup",
-  "version": "0.0.1",
-  "description": "Easily popups like alerts and modals in React with a single hook",
+  "version": "0.0.2",
+  "description": "Easily manage popups like alerts and modals in React with a single hook",
   "homepage": "https://github.com/aidanjw1/react-hook-popup#readme",
   "repository": "github:aidanjw1/react-hook-popup",
   "main": "dist/index.js",

--- a/src/PopupProvider.tsx
+++ b/src/PopupProvider.tsx
@@ -11,36 +11,33 @@ export const PopupProvider = ({ children }: Props): JSX.Element => {
     const addPopup = (key: string, popupRenderer: PopupRenderer): void => {
         setPopups((previous) => {
             if (previous[key]) {
-                throw Error(`Alerts were created with duplicate key: '${key}'`);
+                return previous;
             }
             return {
                 ...previous,
                 [key]: {
                     renderer: popupRenderer,
                     open: false,
-                }
+                },
             };
         });
     };
     const removePopup = (key: string) => {
-        if (!popups[key]) {
-            throw Error(`Attempted to remove non-existing alert with key: ${key}`);
-        }
         setPopups((previous) => {
             const updatedPopups = { ...previous };
             delete updatedPopups[key];
             return updatedPopups;
-        })
+        });
     };
     const displayPopup = (key: string, message: string): void => {
-        setPopups({
-            ...popups,
+        setPopups((previous) => ({
+            ...previous,
             [key]: {
                 ...popups[key],
                 open: true,
                 message,
             },
-        });
+        }));
     };
     const closePopup = (key: string): void => {
         setPopups((previous) => ({
@@ -69,8 +66,8 @@ export const PopupProvider = ({ children }: Props): JSX.Element => {
                         popup.renderer?.({
                             message: popup.message,
                             handleClose: () => closePopup(key),
-                        }), 
-                        { key }
+                        }),
+                        { key },
                     )
                 );
             })}

--- a/src/usePopup.ts
+++ b/src/usePopup.ts
@@ -1,10 +1,7 @@
 import { useContext, useEffect } from 'react';
 import { PopupContext } from './PopupContext';
 
-type ReturnType = [
-    (message: string) => void,
-    () => void,
-]
+type ReturnType = [(message: string) => void, () => void];
 
 export function usePopup(key: string, popupRenderer: PopupRenderer): ReturnType {
     const { addPopup, removePopup, displayPopup, closePopup } = useContext(PopupContext);

--- a/test/utils.tsx
+++ b/test/utils.tsx
@@ -2,28 +2,32 @@ import React from 'react';
 import { mount, ReactWrapper } from "enzyme";
 import { PopupProvider, usePopup } from "../src";
 
-export const TestComponent = (): JSX.Element => {
-    const [showPopup1, hidePopup1] = usePopup('popup', ({ message, handleClose }) => (
-        <>
-            <span>{message}</span>
-            <button className="close" onClick={handleClose}>Close</button>
-        </>
-    ));
-    const [showPopup2, hidePopup2] = usePopup('popup-2', ({ message, handleClose }) => (
-        <>
-            <span>{message}</span>
-            <button className="close-2" onClick={handleClose}>Close</button>
-        </>
-    ));
-    return (
-        <>
-            <button className="show" onClick={() => showPopup1('popup')}>Show</button>
-            <button className="hide" onClick={() => hidePopup1()}>Hide</button>
-
-            <button className="show-2" onClick={() => showPopup2('popup 2')}>Show</button>
-            <button className="hide-2" onClick={() => hidePopup2()}>Hide</button>
-        </>
-    );
+export class TestComponentFactory {
+    public static getTestComponent(): React.ComponentType {
+        return (): JSX.Element => {
+            const [showPopup1, hidePopup1] = usePopup('popup', ({ message, handleClose }) => (
+                <>
+                    <span>{message}</span>
+                    <button className="close" onClick={handleClose}>Close</button>
+                </>
+            ));
+            const [showPopup2, hidePopup2] = usePopup('popup-2', ({ message, handleClose }) => (
+                <>
+                    <span>{message}</span>
+                    <button className="close-2" onClick={handleClose}>Close</button>
+                </>
+            ));
+            return (
+                <>
+                    <button className="show" onClick={() => showPopup1('popup')}>Show</button>
+                    <button className="hide" onClick={() => hidePopup1()}>Hide</button>
+        
+                    <button className="show-2" onClick={() => showPopup2('popup 2')}>Show</button>
+                    <button className="hide-2" onClick={() => hidePopup2()}>Hide</button>
+                </>
+            );
+        };
+    }
 }
 
 export function mountWithContext(Component: JSX.Element): ReactWrapper {


### PR DESCRIPTION
usePopup hook can now be re-used and shared between different components. Re-running the hook the same key but a different renderer will not overwrite the first renderer.